### PR TITLE
fix: Add forwarded headers for Cloud Run OAuth

### DIFF
--- a/src/FlatRate.Web/Program.cs
+++ b/src/FlatRate.Web/Program.cs
@@ -18,11 +18,14 @@ using Microsoft.Extensions.FileProviders;
 var builder = WebApplication.CreateBuilder(args);
 
 // Configure forwarded headers for Cloud Run (TLS termination at load balancer)
-builder.Services.Configure<ForwardedHeadersOptions>(options =>
+if (!builder.Environment.IsDevelopment())
 {
-    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
-    options.ForwardLimit = null; // Allow any number of proxies
-});
+    builder.Services.Configure<ForwardedHeadersOptions>(options =>
+    {
+        options.ForwardedHeaders = ForwardedHeaders.XForwardedProto;
+        options.ForwardLimit = 1;
+    });
+}
 
 // Add Application services (MediatR handlers)
 builder.Services.AddApplication();
@@ -99,7 +102,10 @@ builder.Services.AddAuthorization();
 
 var app = builder.Build();
 
-app.UseForwardedHeaders();
+if (!app.Environment.IsDevelopment())
+{
+    app.UseForwardedHeaders();
+}
 
 // Apply database migrations on startup
 const int maxRetries = 5;


### PR DESCRIPTION
## Summary

- Add `ForwardedHeaders` middleware so ASP.NET correctly generates `https://` redirect URIs behind Cloud Run's TLS-terminating load balancer
- Without this, Google OAuth fails with `redirect_uri_mismatch` because the app constructs `http://` callback URLs

## Test plan

- [x] `dotnet build` succeeds (0 warnings)
- [x] `dotnet test` — 113 unit tests pass
- [x] E2E tests — 11 tests pass
- [ ] Verify Google OAuth login works on Cloud Run after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix incorrect OAuth redirect URIs by enabling processing of X-Forwarded-For and X-Forwarded-Proto headers when running behind Cloud Run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced application infrastructure to properly handle network requests in cloud and proxy-based environments, ensuring accurate processing of client information and secure connections when deployed behind load balancers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->