### PR TITLE
fix: Clear KnownProxies for Cloud Run forwarded headers

### DIFF
--- a/src/FlatRate.Web/Program.cs
+++ b/src/FlatRate.Web/Program.cs
@@ -24,6 +24,7 @@ if (!builder.Environment.IsDevelopment())
     {
         options.ForwardedHeaders = ForwardedHeaders.XForwardedProto;
         options.ForwardLimit = 1;
+        options.KnownProxies.Clear();
     });
 }
 


### PR DESCRIPTION
## Summary

- Add `KnownProxies.Clear()` so the `ForwardedHeaders` middleware actually processes `X-Forwarded-Proto` from Cloud Run's load balancer
- Without this, the middleware silently ignores the header because Cloud Run's proxy IP isn't in the default known list, causing OAuth to generate `http://` redirect URIs

## Test plan

- [x] `dotnet build` — 0 warnings
- [x] `dotnet test` — 113 unit tests pass
- [ ] Verify Google OAuth login works on Cloud Run (redirect URI should use `https://`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent OAuth redirects from incorrectly using http by clearing the default KnownProxies so Cloud Run X-Forwarded-Proto headers are processed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated proxy trust configuration in production environments to ensure stricter proxy validation for forwarded headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->