### PR TITLE
feat: Redesign invoice PDF with Nord-themed Split Header + Grid Statement layout

### DIFF
--- a/src/FlatRate.Web/Services/InvoicePdfService.cs
+++ b/src/FlatRate.Web/Services/InvoicePdfService.cs
@@ -230,10 +230,11 @@ public sealed class InvoicePdfService
     {
         var bgColor = isDark ? Nord0 : Nord6;
         var valueColor = isDark ? Nord13 : Nord0;
+        var labelColor = isDark ? Nord4 : Nord3;
 
         container.Background(bgColor).Padding(12).Column(col =>
         {
-            col.Item().AlignCenter().Text(label).FontSize(7).FontColor(Nord3).LetterSpacing(0.08f);
+            col.Item().AlignCenter().Text(label).FontSize(7).FontColor(labelColor).LetterSpacing(0.08f);
             col.Item().PaddingTop(4).AlignCenter().Text(value).FontSize(13).Bold().FontColor(valueColor);
         });
     }
@@ -250,23 +251,21 @@ public sealed class InvoicePdfService
 
     private static void HeaderCell(IContainer container, string text, bool alignRight)
     {
-        var cell = container.Background(Nord6).Padding(8);
+        IContainer cell = container.Background(Nord6).Padding(8);
         if (alignRight)
-            cell.AlignRight().Text(text).FontSize(8).Bold().FontColor(Nord2);
-        else
-            cell.Text(text).FontSize(8).Bold().FontColor(Nord2);
+            cell = cell.AlignRight();
+        cell.Text(text).FontSize(8).Bold().FontColor(Nord2);
     }
 
     private static void BodyCell(TableDescriptor table, string text, bool alignRight, bool lastRow)
     {
-        var cell = lastRow
+        IContainer cell = lastRow
             ? table.Cell().Padding(8)
             : table.Cell().BorderBottom(1).BorderColor(Nord5).Padding(8);
 
         if (alignRight)
-            cell.AlignRight().Text(text).FontSize(9).FontColor(Nord0);
-        else
-            cell.Text(text).FontSize(9).FontColor(Nord0);
+            cell = cell.AlignRight();
+        cell.Text(text).FontSize(9).FontColor(Nord0);
     }
 
     private static void BodyCellBold(TableDescriptor table, string text, bool lastRow)


### PR DESCRIPTION
## Summary
- Replaces the entire `InvoicePdfService.cs` with a new Nord-themed "Split Header + Grid Statement" (Variant D) layout
- Full-width dark header band (Nord0) with Aurora Yellow logo mark, "FlatRate" brand, and INVOICE badge
- 4-column bordered info grid (Billed To, Location, Period, Issued), themed meter readings table, cost breakdown table (3 items only), and 4 summary cards (Subtotal, VAT, Items, Total Due)
- Removes all `Colors.Blue.*` and `Colors.Grey.*` references, replaced with static Nord palette constants
- Extracts reusable helper methods (HeaderCell, BodyCell, BodyCellBold, SummaryCard, InfoGridCell) to reduce repetition

Closes #37

## Test plan
- [x] `dotnet build src/FlatRate.slnx` compiles with 0 errors, 0 warnings
- [x] `dotnet test src/FlatRate.slnx` — all 161 tests pass (135 domain + 26 application)
- [x] No `Colors.Blue` or `Colors.Grey` references remain in the file
- [x] `GenerateInvoicePdfAsync` signature unchanged — no caller modifications needed
- [ ] PDF generates and downloads correctly from the UI (visual verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invoice PDFs now feature a Nord-themed visual redesign with updated color palette and typography
  * New header layout includes logo, brand text, and invoice badge with date/number display
  * Added information grid displaying billing details (Billed To, Location, Period, Issued)
  * Meter readings and cost breakdown now presented in tabular format
  * Summary cards highlight Subtotal, VAT, Items, and Total Due with distinct styling
  * Updated footer with Nord-themed styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->