### PR TITLE
fix: Serialize PropertyRole enum as string instead of integer

### DIFF
--- a/src/FlatRate.Web/Program.cs
+++ b/src/FlatRate.Web/Program.cs
@@ -30,6 +30,12 @@ builder.Services.AddScoped<InvoicePdfService>();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();
 
+// Serialize enums as strings in API responses (e.g. PropertyRole)
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
+});
+
 // Authentication setup
 var isDevelopment = builder.Environment.IsDevelopment();
 


### PR DESCRIPTION
## Summary

- Add `JsonStringEnumConverter` to `ConfigureHttpJsonOptions` so all enums (e.g., `PropertyRole`) are serialized as `"Owner"` / `"Editor"` strings instead of `0` / `1` integers in API responses
- Fixes broken Share, Delete, and collaborator role UI features that depend on string comparisons

Closes #47

## Test plan

- [x] `dotnet build` compiles with zero warnings
- [x] All 169 unit tests pass (140 Domain + 29 Application)
- [x] `GET /api/properties` returns `currentUserRole` as `"Owner"` (string, not `0`)
- [x] `GET /api/properties/{id}/collaborators` returns `role` as `"Owner"` (string, not `0`)
- [x] Share and Delete buttons visible on Properties page in browser
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Restore correct behavior of UI features that rely on string enum values in API responses, such as property sharing, deletion, and collaborator role handling.