### PR TITLE
feat: Redesign tariff rates with fieldset grouping by utility type

### DIFF
--- a/src/FlatRate.Web/ClientApp/src/app/bills/create-bill.page.ts
+++ b/src/FlatRate.Web/ClientApp/src/app/bills/create-bill.page.ts
@@ -254,12 +254,13 @@ import { formatDateToISO } from '../core/utils/date-utils';
           </p>
           <div class="flex flex-col gap-4">
             <!-- Electricity -->
-            <div class="relative rounded-[10px] border-[1.5px] p-4 pt-5" style="border-color: var(--color-border);">
-              <div class="absolute -top-2.5 left-4 px-2 text-xs font-semibold uppercase tracking-wide"
+            <div class="relative rounded-[10px] border-[1.5px] p-4 pt-5" style="border-color: var(--color-border);"
+                 role="group" aria-labelledby="bill-electricity-legend">
+              <div id="bill-electricity-legend" class="absolute -top-2.5 left-4 px-2 text-xs font-semibold uppercase tracking-wide"
                    style="background: var(--color-bg-card); color: var(--color-warning);">
                 ⚡ Electricity
               </div>
-              <div class="grid grid-cols-1 gap-4" style="max-width: 33%;">
+              <div class="grid grid-cols-1 gap-4 md:max-w-[33%]">
                 <div class="flex flex-col gap-2">
                   <label for="elecRate" class="font-medium">Rate (per kWh)</label>
                   <p-inputNumber
@@ -280,8 +281,9 @@ import { formatDateToISO } from '../core/utils/date-utils';
             </div>
 
             <!-- Water -->
-            <div class="relative rounded-[10px] border-[1.5px] p-4 pt-5" style="border-color: var(--color-border);">
-              <div class="absolute -top-2.5 left-4 px-2 text-xs font-semibold uppercase tracking-wide"
+            <div class="relative rounded-[10px] border-[1.5px] p-4 pt-5" style="border-color: var(--color-border);"
+                 role="group" aria-labelledby="bill-water-legend">
+              <div id="bill-water-legend" class="absolute -top-2.5 left-4 px-2 text-xs font-semibold uppercase tracking-wide"
                    style="background: var(--color-bg-card); color: var(--color-info);">
                 💧 Water
               </div>
@@ -338,8 +340,9 @@ import { formatDateToISO } from '../core/utils/date-utils';
             </div>
 
             <!-- Sanitation -->
-            <div class="relative rounded-[10px] border-[1.5px] p-4 pt-5" style="border-color: var(--color-border);">
-              <div class="absolute -top-2.5 left-4 px-2 text-xs font-semibold uppercase tracking-wide"
+            <div class="relative rounded-[10px] border-[1.5px] p-4 pt-5" style="border-color: var(--color-border);"
+                 role="group" aria-labelledby="bill-sanitation-legend">
+              <div id="bill-sanitation-legend" class="absolute -top-2.5 left-4 px-2 text-xs font-semibold uppercase tracking-wide"
                    style="background: var(--color-bg-card); color: var(--color-success);">
                 ♻ Sanitation
               </div>

--- a/src/FlatRate.Web/ClientApp/src/app/properties/properties.page.ts
+++ b/src/FlatRate.Web/ClientApp/src/app/properties/properties.page.ts
@@ -255,8 +255,9 @@ import { Property, SetPropertyRatesRequest } from '../core/models/property.model
         </div>
         <div class="flex flex-col gap-4">
           <!-- Electricity -->
-          <div class="relative rounded-[10px] border-[1.5px] p-4 pt-5" style="border-color: var(--color-border);">
-            <div class="absolute -top-2.5 left-4 px-2 text-xs font-semibold uppercase tracking-wide"
+          <div class="relative rounded-[10px] border-[1.5px] p-4 pt-5" style="border-color: var(--color-border);"
+               role="group" aria-labelledby="rates-electricity-legend">
+            <div id="rates-electricity-legend" class="absolute -top-2.5 left-4 px-2 text-xs font-semibold uppercase tracking-wide"
                  style="background: var(--color-bg-card); color: var(--color-warning);">
               ⚡ Electricity
             </div>
@@ -268,6 +269,7 @@ import { Property, SetPropertyRatesRequest } from '../core/models/property.model
                   [(ngModel)]="ratesForm.electricityRate"
                   mode="decimal"
                   [useGrouping]="false"
+                  [min]="0"
                   [minFractionDigits]="2"
                   [maxFractionDigits]="4"
                   prefix="R "
@@ -278,8 +280,9 @@ import { Property, SetPropertyRatesRequest } from '../core/models/property.model
           </div>
 
           <!-- Water -->
-          <div class="relative rounded-[10px] border-[1.5px] p-4 pt-5" style="border-color: var(--color-border);">
-            <div class="absolute -top-2.5 left-4 px-2 text-xs font-semibold uppercase tracking-wide"
+          <div class="relative rounded-[10px] border-[1.5px] p-4 pt-5" style="border-color: var(--color-border);"
+               role="group" aria-labelledby="rates-water-legend">
+            <div id="rates-water-legend" class="absolute -top-2.5 left-4 px-2 text-xs font-semibold uppercase tracking-wide"
                  style="background: var(--color-bg-card); color: var(--color-info);">
               💧 Water
             </div>
@@ -291,6 +294,7 @@ import { Property, SetPropertyRatesRequest } from '../core/models/property.model
                   [(ngModel)]="ratesForm.waterRateTier1"
                   mode="decimal"
                   [useGrouping]="false"
+                  [min]="0"
                   [minFractionDigits]="2"
                   [maxFractionDigits]="4"
                   prefix="R "
@@ -304,6 +308,7 @@ import { Property, SetPropertyRatesRequest } from '../core/models/property.model
                   [(ngModel)]="ratesForm.waterRateTier2"
                   mode="decimal"
                   [useGrouping]="false"
+                  [min]="0"
                   [minFractionDigits]="2"
                   [maxFractionDigits]="4"
                   prefix="R "
@@ -317,6 +322,7 @@ import { Property, SetPropertyRatesRequest } from '../core/models/property.model
                   [(ngModel)]="ratesForm.waterRateTier3"
                   mode="decimal"
                   [useGrouping]="false"
+                  [min]="0"
                   [minFractionDigits]="2"
                   [maxFractionDigits]="4"
                   prefix="R "
@@ -327,8 +333,9 @@ import { Property, SetPropertyRatesRequest } from '../core/models/property.model
           </div>
 
           <!-- Sanitation -->
-          <div class="relative rounded-[10px] border-[1.5px] p-4 pt-5" style="border-color: var(--color-border);">
-            <div class="absolute -top-2.5 left-4 px-2 text-xs font-semibold uppercase tracking-wide"
+          <div class="relative rounded-[10px] border-[1.5px] p-4 pt-5" style="border-color: var(--color-border);"
+               role="group" aria-labelledby="rates-sanitation-legend">
+            <div id="rates-sanitation-legend" class="absolute -top-2.5 left-4 px-2 text-xs font-semibold uppercase tracking-wide"
                  style="background: var(--color-bg-card); color: var(--color-success);">
               ♻ Sanitation
             </div>
@@ -340,6 +347,7 @@ import { Property, SetPropertyRatesRequest } from '../core/models/property.model
                   [(ngModel)]="ratesForm.sanitationRateTier1"
                   mode="decimal"
                   [useGrouping]="false"
+                  [min]="0"
                   [minFractionDigits]="2"
                   [maxFractionDigits]="4"
                   prefix="R "
@@ -353,6 +361,7 @@ import { Property, SetPropertyRatesRequest } from '../core/models/property.model
                   [(ngModel)]="ratesForm.sanitationRateTier2"
                   mode="decimal"
                   [useGrouping]="false"
+                  [min]="0"
                   [minFractionDigits]="2"
                   [maxFractionDigits]="4"
                   prefix="R "
@@ -366,6 +375,7 @@ import { Property, SetPropertyRatesRequest } from '../core/models/property.model
                   [(ngModel)]="ratesForm.sanitationRateTier3"
                   mode="decimal"
                   [useGrouping]="false"
+                  [min]="0"
                   [minFractionDigits]="2"
                   [maxFractionDigits]="4"
                   prefix="R "


### PR DESCRIPTION
Closes #46

## Summary

- Replace flat 3-column grid of tariff rate inputs with bordered fieldset containers grouped by utility type (Electricity, Water, Sanitation)
- Each fieldset has a color-coded floating legend label: ⚡ ELECTRICITY (amber), 💧 WATER (teal), ♻ SANITATION (green)
- Applied same fieldset layout to both the Create Bill page and the Set Default Rates dialog on the Properties page
- Increased Set Rates dialog maxWidth from 600px to 700px to fit 3 tier inputs comfortably

## Test plan

- [x] `dotnet build` compiles without errors
- [x] All 171 unit tests pass
- [ ] CI passes (GitHub Actions)
- [x] Browser validation: Create Bill page fieldsets render correctly (light mode)
- [x] Browser validation: Set Default Rates dialog fieldsets render correctly (light mode)
- [x] Browser validation: Both pages render correctly in dark mode
- [ ] Verify existing bill creation functionality is preserved (all bindings intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned Tariff Rates UI on Create Bill and Properties pages with card-based sections for Electricity, Water, and Sanitation inputs, featuring visual badges and icons.
  * Adjusted dialog width on Properties page for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->