### PR TITLE
fix: Add Tooltip import for Bills page icon buttons

### DIFF
--- a/src/FlatRate.Web/ClientApp/src/app/bills/bills.page.ts
+++ b/src/FlatRate.Web/ClientApp/src/app/bills/bills.page.ts
@@ -11,6 +11,7 @@ import { ToastModule } from 'primeng/toast';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DialogModule } from 'primeng/dialog';
 import { DividerModule } from 'primeng/divider';
+import { Tooltip } from 'primeng/tooltip';
 import { MessageService, ConfirmationService } from 'primeng/api';
 import { PropertyService } from '../core/services/property.service';
 import { BillService } from '../core/services/bill.service';
@@ -32,7 +33,8 @@ import { formatDateToISO } from '../core/utils/date-utils';
     ToastModule,
     ConfirmDialogModule,
     DialogModule,
-    DividerModule
+    DividerModule,
+    Tooltip
   ],
   providers: [MessageService, ConfirmationService],
   template: `


### PR DESCRIPTION
## Summary
- Add missing `Tooltip` directive import from `primeng/tooltip` to the Bills page component
- This fixes the `pTooltip` attributes on the View Details and Delete icon buttons, which were silently ignored because the directive was not in the component's `imports` array
- No template changes needed -- the `pTooltip` attributes were already correctly placed

Closes #51

## Test plan
- [x] `dotnet build` passes with 0 warnings and 0 errors
- [x] Angular `ng build` compiles successfully
- [x] All 171 unit tests pass
- [x] Hover over the eye (View) icon button in the Bills table -- "View Details" tooltip appears
- [x] Hover over the trash (Delete) icon button in the Bills table -- "Delete" tooltip appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)