### PR TITLE
fix: Replace emoji icons with PrimeNG icons in tariff fieldsets

### DIFF
--- a/src/FlatRate.Web/ClientApp/src/app/bills/create-bill.page.ts
+++ b/src/FlatRate.Web/ClientApp/src/app/bills/create-bill.page.ts
@@ -258,7 +258,7 @@ import { formatDateToISO } from '../core/utils/date-utils';
                  role="group" aria-labelledby="bill-electricity-legend">
               <div id="bill-electricity-legend" class="absolute -top-2.5 left-4 px-2 text-xs font-semibold uppercase tracking-wide"
                    style="background: var(--color-bg-card); color: var(--color-warning);">
-                ⚡ Electricity
+                <i class="pi pi-bolt"></i> Electricity
               </div>
               <div class="grid grid-cols-1 gap-4 md:max-w-[33%]">
                 <div class="flex flex-col gap-2">
@@ -285,7 +285,7 @@ import { formatDateToISO } from '../core/utils/date-utils';
                  role="group" aria-labelledby="bill-water-legend">
               <div id="bill-water-legend" class="absolute -top-2.5 left-4 px-2 text-xs font-semibold uppercase tracking-wide"
                    style="background: var(--color-bg-card); color: var(--color-info);">
-                💧 Water
+                <i class="pi pi-wave-pulse"></i> Water
               </div>
               <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div class="flex flex-col gap-2">
@@ -344,7 +344,7 @@ import { formatDateToISO } from '../core/utils/date-utils';
                  role="group" aria-labelledby="bill-sanitation-legend">
               <div id="bill-sanitation-legend" class="absolute -top-2.5 left-4 px-2 text-xs font-semibold uppercase tracking-wide"
                    style="background: var(--color-bg-card); color: var(--color-success);">
-                ♻ Sanitation
+                <i class="pi pi-sync"></i> Sanitation
               </div>
               <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div class="flex flex-col gap-2">

--- a/src/FlatRate.Web/ClientApp/src/app/properties/properties.page.ts
+++ b/src/FlatRate.Web/ClientApp/src/app/properties/properties.page.ts
@@ -259,7 +259,7 @@ import { Property, SetPropertyRatesRequest } from '../core/models/property.model
                role="group" aria-labelledby="rates-electricity-legend">
             <div id="rates-electricity-legend" class="absolute -top-2.5 left-4 px-2 text-xs font-semibold uppercase tracking-wide"
                  style="background: var(--color-bg-card); color: var(--color-warning);">
-              ⚡ Electricity
+              <i class="pi pi-bolt"></i> Electricity
             </div>
             <div class="grid grid-cols-1 gap-4">
               <div class="flex flex-col gap-2">
@@ -284,7 +284,7 @@ import { Property, SetPropertyRatesRequest } from '../core/models/property.model
                role="group" aria-labelledby="rates-water-legend">
             <div id="rates-water-legend" class="absolute -top-2.5 left-4 px-2 text-xs font-semibold uppercase tracking-wide"
                  style="background: var(--color-bg-card); color: var(--color-info);">
-              💧 Water
+              <i class="pi pi-wave-pulse"></i> Water
             </div>
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
               <div class="flex flex-col gap-2">
@@ -337,7 +337,7 @@ import { Property, SetPropertyRatesRequest } from '../core/models/property.model
                role="group" aria-labelledby="rates-sanitation-legend">
             <div id="rates-sanitation-legend" class="absolute -top-2.5 left-4 px-2 text-xs font-semibold uppercase tracking-wide"
                  style="background: var(--color-bg-card); color: var(--color-success);">
-              ♻ Sanitation
+              <i class="pi pi-sync"></i> Sanitation
             </div>
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
               <div class="flex flex-col gap-2">


### PR DESCRIPTION
## Summary

Unicode emojis (⚡💧♻) in the tariff rate fieldset legends render with native OS colors that don't respect the CSS `color` property, clashing with the Nord theme.

Replaced with PrimeNG icons that inherit the semantic color tokens:
- ⚡ → `pi-bolt` (Electricity, `--color-warning`)
- 💧 → `pi-wave-pulse` (Water, `--color-info`)
- ♻ → `pi-sync` (Sanitation, `--color-success`)

**Files changed:** `create-bill.page.ts`, `properties.page.ts`

## Test plan

- [x] `dotnet build` passes with 0 warnings
- [ ] Icons render in theme colors on Create Bill page
- [ ] Icons render in theme colors on Properties page (default rates)
- [ ] Icons work in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)