### PR TITLE
docs: Add live URL to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Monthly utility billing for rental properties. Generate electricity, water, and sanitation invoices with tiered tariff calculations and PDF export.
 
+**Live app**: https://flatrate-fjbytiknsa-ts.a.run.app
+
 ## Features
 
 - **Multi-user property sharing**: Share properties with family members via Google OAuth login


### PR DESCRIPTION
## Summary

- Adds the live Cloud Run URL to the top of the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Add a prominent link to the live Cloud Run application at the top of the README.